### PR TITLE
fix verify() throw on bad prior hash

### DIFF
--- a/easy-pbkdf2.js
+++ b/easy-pbkdf2.js
@@ -208,7 +208,7 @@ EasyPbkdf2.prototype = {
 			return;
 		}
 		keyLength = base64toBinary( priorHash ).length;
-		easyPbkdf2 = new EasyPbkdf2({ "KEY_LENGTH": keyLength })
+		easyPbkdf2 = new EasyPbkdf2({ "KEY_LENGTH": keyLength });
 		easyPbkdf2.hash( value, salt, function( err, valueHash ) {
 			var valid;
 			if ( !err ) {


### PR DESCRIPTION
This pull request modifies the `verify()` method to catch errors created by feeding a bad prior hash into the new Buffer. A new descriptive error is then passed to the callback.

Thanks for the library! :+1: 
