### PR TITLE
Update version number in README.md documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or in your `package.json`:
 
 ```json
 "dependencies": {
-    "easy-pbkdf2": "0.0.2"
+    "easy-pbkdf2": "0.x.x"
 }
 ```
 


### PR DESCRIPTION
Hi there! I found a mistake in the README. After installing version 0.0.2 as a dependency per the README, it took me an hour to figure out why the "verify" function was undefined. I just needed to update to the newest version.

Not sure if you would rather put the exact version number as the dependency or use the 0.x.x notation.

Thanks for this! Great work.
